### PR TITLE
Changing jib behaviour to have current timestamp rather than start of Unix epoch as image creation time.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,7 @@
                                 <jvmFlag>-XX:MaxInlineLevel=15</jvmFlag>
                                 <jvmFlag>-Djava.awt.headless=true</jvmFlag>
                             </jvmFlags>
+                            <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         </container>
                     </configuration>
                     <executions>


### PR DESCRIPTION
I've just tried building locally and found it confusing to see Docker indicating that the image was created 52 years ago.

So I did some digging and came across:
https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago

I have a preference for the metadata indicating the actual image creation time.

If someone really wants to reproduce the build then presumably they could just specify the image's timestamp in place of USE_CURRENT_TIMESTAMP.