### PR TITLE
Logging update for 3.2.0 reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
                 <version>${log4j2.version}</version>
             </dependency>
 
-            <!-- Setup kafka-clients to exclude log4j 1.x -->
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
@@ -183,14 +182,14 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
 
-        <!-- Setup kafka-clients to exclude log4j 1.x -->
+        <!-- Setup kafka-clients to exclude reload4j (log4j 1.x compatible logging) -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -289,7 +288,6 @@
                                 <jvmFlag>-XX:MaxInlineLevel=15</jvmFlag>
                                 <jvmFlag>-Djava.awt.headless=true</jvmFlag>
                             </jvmFlags>
-                            <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         </container>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,7 @@
                                 <jvmFlag>-XX:MaxInlineLevel=15</jvmFlag>
                                 <jvmFlag>-Djava.awt.headless=true</jvmFlag>
                             </jvmFlags>
+                            <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         </container>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -186,12 +186,6 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.reload4j</groupId>
-                    <artifactId>reload4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Kafka Connect API -->
@@ -206,6 +200,10 @@
                 <exclusion>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka-tools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.reload4j</groupId>
+                    <artifactId>reload4j</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Since 3.2.0 now uses reload4j rather than log4j 1, if you want to continue to swap in log4j2 instead then we should update the dependency exclusion to leave out reload4j instead of log4j.