### PR TITLE
Making it so that forks of the project don't attempt to build and deploy from a github action when there is a push to master.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'OneCricketeer/apache-kafka-connect-docker'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This is based on what I've seen at:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository

Disclaimer: I haven't tried this on my master branch, but will pull it down and verify it if you merge it in.