### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -36,7 +36,7 @@ x-kraft: &kraft-vars
 
 services:
   kafka-controller:
-    image: &kafka-image bitnami/kafka:4.0.0
+    image: &kafka-image soldevelo/kafka:4.0.0
     restart: unless-stopped
     volumes:
       - 'kafka_controller_data:/bitnami/kafka'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ x-connect: &connect-vars
 
 services:
   kafka:
-    image: bitnami/kafka:4.0.0
+    image: soldevelo/kafka:4.0.0
     restart: unless-stopped
     ports:
       - '9092:9092'


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kafka:4.0.0` → [`soldevelo/kafka:4.0.0`](https://hub.docker.com/r/soldevelo/kafka)